### PR TITLE
Add gear and stat system

### DIFF
--- a/qb-gear/README.md
+++ b/qb-gear/README.md
@@ -1,0 +1,12 @@
+# qb-gear
+
+This resource implements a basic gear and stat system for QBCore.
+It is designed to integrate with the TGIANN inventory system and
+enables players to equip gear items which grant gameplay bonuses.
+
+The script stores equipped gear in player metadata and calculates
+combined stats whenever gear is equipped or unequipped. Stats are
+exported so other resources can make use of them.
+
+It contains minimal functionality and should be expanded to suit
+your server's needs.

--- a/qb-gear/client.lua
+++ b/qb-gear/client.lua
@@ -1,0 +1,36 @@
+local stats = {}
+
+local function ApplyStats(newStats)
+    stats = newStats or {}
+    local ped = PlayerPedId()
+    local moveMult = 1.0 + ((stats.moveSpeed or 0) / 100.0)
+    moveMult = math.min(moveMult, 1.49)
+    SetRunSprintMultiplierForPlayer(PlayerId(), moveMult)
+    local maxHealth = 200 + (stats.healthBonus or 0)
+    SetEntityMaxHealth(ped, maxHealth)
+    if GetEntityHealth(ped) > maxHealth then
+        SetEntityHealth(ped, maxHealth)
+    end
+end
+
+RegisterNetEvent('qb-gear:client:ApplyStats', function(newStats)
+    ApplyStats(newStats)
+end)
+
+-- Display stats in chat
+RegisterNetEvent('qb-gear:client:ShowStats', function(current)
+    local msg = 'Current Gear Stats:\n'
+    for k, v in pairs(current) do
+        msg = msg .. ('%s: %s\n'):format(k, v)
+    end
+    TriggerEvent('chat:addMessage', {args = {msg}})
+end)
+
+-- reapplies after spawn
+AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
+    TriggerServerEvent('qb-gear:server:RequestStats')
+end)
+
+RegisterNetEvent('qb-gear:client:SyncStats', function(newStats)
+    ApplyStats(newStats)
+end)

--- a/qb-gear/config.lua
+++ b/qb-gear/config.lua
@@ -1,0 +1,37 @@
+Config = {}
+
+-- Gear slot names
+Config.GearSlots = {
+    'head',
+    'chest',
+    'gloves',
+    'backpack',
+    'legs',
+    'boots',
+    'mod_1',
+    'mod_2',
+    'weapon_attachment'
+}
+
+-- Default empty stat table
+Config.DefaultStats = {
+    weaponDamage = 0,
+    critChance = 0,
+    critDamage = 0,
+    reloadSpeed = 0,
+    magazine = 0,
+    cooldownReduction = 0,
+    healthBonus = 0,
+    armor = 0,
+    statusResist = 0,
+    moveSpeed = 0,
+}
+
+-- Example rarity multipliers used when rolling item stats
+Config.RarityMultipliers = {
+    common = 1.0,
+    uncommon = 1.2,
+    rare = 1.4,
+    epic = 1.7,
+    legendary = 2.0
+}

--- a/qb-gear/fxmanifest.lua
+++ b/qb-gear/fxmanifest.lua
@@ -1,0 +1,22 @@
+fx_version 'cerulean'
+lua54 'yes'
+game 'gta5'
+
+name 'qb-gear'
+description 'Looter shooter gear and stat system'
+version '0.1.0'
+
+dependency 'qb-core'
+
+shared_scripts {
+    'config.lua'
+}
+
+server_scripts {
+    '@oxmysql/lib/MySQL.lua',
+    'server.lua'
+}
+
+client_scripts {
+    'client.lua'
+}

--- a/qb-gear/server.lua
+++ b/qb-gear/server.lua
@@ -1,0 +1,116 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+local Gear = {}
+
+local function deepcopy(orig)
+    local copy = {}
+    for k, v in pairs(orig) do
+        if type(v) == 'table' then
+            copy[k] = deepcopy(v)
+        else
+            copy[k] = v
+        end
+    end
+    return copy
+end
+
+local function MergeStats(stats, itemStats)
+    for stat, value in pairs(itemStats or {}) do
+        stats[stat] = (stats[stat] or 0) + (tonumber(value) or 0)
+    end
+end
+
+local function CalculateStats(gear)
+    local totals = deepcopy(Config.DefaultStats)
+    for _, data in pairs(gear or {}) do
+        MergeStats(totals, data.info and data.info.stats)
+    end
+    return totals
+end
+
+local function SaveGear(Player, gear, stats)
+    Player.Functions.SetMetaData('gear', gear)
+    Player.Functions.SetMetaData('gearstats', stats)
+    Player.Functions.UpdatePlayerData()
+end
+
+local function LoadPlayerGear(Player)
+    local gear = Player.PlayerData.metadata.gear or {}
+    local stats = CalculateStats(gear)
+    Gear[Player.PlayerData.source] = {gear = gear, stats = stats}
+    TriggerClientEvent('qb-gear:client:ApplyStats', Player.PlayerData.source, stats)
+end
+
+RegisterNetEvent('QBCore:Server:PlayerLoaded', function(Player)
+    LoadPlayerGear(Player)
+end)
+
+AddEventHandler('playerDropped', function()
+    local src = source
+    Gear[src] = nil
+end)
+
+local function GetPlayerGear(Player)
+    return Gear[Player.PlayerData.source] and Gear[Player.PlayerData.source].gear or {}
+end
+
+local function SetPlayerGear(Player, gear)
+    local stats = CalculateStats(gear)
+    Gear[Player.PlayerData.source] = {gear = gear, stats = stats}
+    SaveGear(Player, gear, stats)
+    TriggerClientEvent('qb-gear:client:ApplyStats', Player.PlayerData.source, stats)
+end
+
+-- Export for other resources to get current stats
+exports('GetPlayerStats', function(playerId)
+    local Player = QBCore.Functions.GetPlayer(playerId)
+    if not Player then return nil end
+    local data = Gear[playerId]
+    return data and data.stats or deepcopy(Config.DefaultStats)
+end)
+
+RegisterNetEvent('qb-gear:server:EquipGear', function(slot, invSlot)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    local item = Player.Functions.GetItemBySlot(invSlot)
+    if not item then return end
+    if not item.info or item.info.slot ~= slot then return end
+
+    local gear = GetPlayerGear(Player)
+    if gear[slot] then
+        -- return existing item
+        Player.Functions.AddItem(gear[slot].name, 1, false, gear[slot].info)
+    end
+    if not Player.Functions.RemoveItem(item.name, 1, invSlot) then return end
+    gear[slot] = {name = item.name, info = item.info}
+    SetPlayerGear(Player, gear)
+end)
+
+RegisterNetEvent('qb-gear:server:UnequipGear', function(slot)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    local gear = GetPlayerGear(Player)
+    if not gear[slot] then return end
+    Player.Functions.AddItem(gear[slot].name, 1, false, gear[slot].info)
+    gear[slot] = nil
+    SetPlayerGear(Player, gear)
+end)
+
+RegisterNetEvent('qb-gear:server:RequestStats', function()
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+    local data = Gear[src]
+    if not data then
+        LoadPlayerGear(Player)
+        data = Gear[src]
+    end
+    TriggerClientEvent('qb-gear:client:SyncStats', src, data.stats)
+end)
+
+-- Simple command to view stats
+QBCore.Commands.Add('gearstats', 'Show current gear stats', {}, false, function(src)
+    local stats = exports['qb-gear']:GetPlayerStats(src)
+    TriggerClientEvent('qb-gear:client:ShowStats', src, stats)
+end)


### PR DESCRIPTION
## Summary
- add a new `qb-gear` resource implementing a basic equipment and stat framework
- include client/server scripts and config
- export player stats for other resources

## Testing
- `No tests provided`
