### PR TITLE
Fix gear system logic and UI

### DIFF
--- a/gear_system/README.md
+++ b/gear_system/README.md
@@ -1,0 +1,13 @@
+# Gear System
+
+Standalone gear and stat system compatible with qb-inventory.
+
+## Commands
+- `/equipment` opens the equipment UI.
+- `/gearstats` prints calculated stats in server console.
+
+To equip gear items via **qb-inventory**, trigger the server event
+`gear_system:server:useItem` when the item is right-clicked.
+
+## Export
+- `exports['gear_system']:getPlayerStats(source)` returns aggregated stats table for a player.

--- a/gear_system/client.lua
+++ b/gear_system/client.lua
@@ -1,0 +1,45 @@
+local currentStats = {}
+
+local function applyWeaponDamage(bonus)
+    SetPlayerWeaponDamageModifier(PlayerId(), 1.0 + bonus / 100.0)
+end
+
+local function applyMovementSpeed(bonus)
+    SetRunSprintMultiplierForPlayer(PlayerId(), 1.0 + bonus / 100.0)
+end
+
+RegisterNetEvent('gear_system:client:applyStats', function(stats)
+    currentStats = stats
+    for stat, value in pairs(stats) do
+        local fnName = Config.StatEffects[stat]
+        if fnName == 'applyWeaponDamage' then
+            applyWeaponDamage(value)
+        elseif fnName == 'applyMovementSpeed' then
+            applyMovementSpeed(value)
+        end
+    end
+end)
+
+RegisterNetEvent('gear_system:client:open', function()
+    SetNuiFocus(true, true)
+    SendNUIMessage({action = 'open'})
+    TriggerServerEvent('gear_system:server:requestGear')
+end)
+
+RegisterNetEvent('gear_system:client:setGear', function(gear)
+    SendNUIMessage({action = 'setGear', gear = gear, slots = Config.GearSlots})
+end)
+
+RegisterNUICallback('close', function(_, cb)
+    SetNuiFocus(false, false)
+    cb('ok')
+end)
+
+RegisterNUICallback('unequip', function(data, cb)
+    TriggerServerEvent('gear_system:server:unequip', data.slot)
+    cb('ok')
+end)
+
+RegisterCommand('equipment', function()
+    TriggerEvent('gear_system:client:open')
+end)

--- a/gear_system/config.lua
+++ b/gear_system/config.lua
@@ -1,0 +1,71 @@
+Config = {}
+
+Config.Equipment = {
+    ["tactical_helmet"] = {
+        label = "Tactical Helmet",
+        slot = "head",
+        type = "helmet",
+        rarity = "rare",
+        durability = 100,
+        stats = {
+            armor = 10,
+            crit_chance = 3
+        }
+    },
+    ["military_vest"] = {
+        label = "Military Vest",
+        slot = "chest",
+        type = "armor",
+        rarity = "epic",
+        durability = 80,
+        stats = {
+            armor = 30,
+            weapon_damage = 8
+        }
+    }
+}
+
+Config.GearSlots = {
+    head = { label = "Helmet", allowedTypes = {"helmet"} },
+    chest = { label = "Body Armor", allowedTypes = {"armor"} },
+    gloves = { label = "Gloves", allowedTypes = {"glove"} },
+    mod_1 = { label = "Attachment 1", allowedTypes = {"mod"} }
+}
+
+Config.Stats = {
+    weapon_damage = {
+        label = "Weapon Damage",
+        type = "percentage",
+        default = 0,
+        max = 100,
+        modifyFunction = "function(base, bonus) return base * (1 + bonus / 100) end"
+    },
+    move_speed = {
+        label = "Movement Speed",
+        type = "percentage",
+        default = 0,
+        max = 50,
+        modifyFunction = "function(base, bonus) return base * (1 + bonus / 100) end"
+    }
+}
+
+Config.Rarities = {
+    common = { color = "#AAAAAA", multiplier = 0.75 },
+    rare = { color = "#0070FF", multiplier = 1.25 },
+    epic = { color = "#A335EE", multiplier = 1.5 },
+    legendary = { color = "#FF8000", multiplier = 2.0 }
+}
+
+Config.Durability = {
+    enabled = true,
+    breakRemovesStats = true,
+    decay = {
+        onHit = 1,
+        onEquip = 0
+    }
+}
+
+Config.StatEffects = {
+    weapon_damage = "applyWeaponDamage",
+    move_speed = "applyMovementSpeed"
+}

--- a/gear_system/fxmanifest.lua
+++ b/gear_system/fxmanifest.lua
@@ -1,0 +1,17 @@
+fx_version 'cerulean'
+game 'gta5'
+
+description 'Standalone Gear and Stat System'
+
+server_script 'server.lua'
+client_script 'client.lua'
+
+shared_script 'config.lua'
+
+files {
+    'html/index.html',
+    'html/style.css',
+    'html/main.js'
+}
+
+ui_page 'html/index.html'

--- a/gear_system/html/index.html
+++ b/gear_system/html/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <div id="gearContainer">
+        <h1>Equipment</h1>
+        <div id="slots"></div>
+        <button id="closeBtn">Close</button>
+    </div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/gear_system/html/main.js
+++ b/gear_system/html/main.js
@@ -1,0 +1,33 @@
+window.addEventListener('message', function(event) {
+    if (event.data.action === 'open') {
+        document.getElementById('gearContainer').style.display = 'block';
+    } else if (event.data.action === 'setGear') {
+        renderGear(event.data.slots, event.data.gear);
+    } else if (event.data.action === 'close') {
+        document.getElementById('gearContainer').style.display = 'none';
+    }
+});
+
+document.getElementById('closeBtn').addEventListener('click', function() {
+    fetch('https://gear_system/close', {method: 'POST'}).then(() => {
+        document.getElementById('gearContainer').style.display = 'none';
+    });
+});
+
+function renderGear(slots, gear) {
+    const slotDiv = document.getElementById('slots');
+    slotDiv.innerHTML = '';
+    for (let slot in slots) {
+        const item = gear[slot];
+        const el = document.createElement('div');
+        el.className = 'slot';
+        el.innerHTML = `<b>${slots[slot].label}</b>: ${item ? item.name : 'Empty'}`;
+        if (item) {
+            const btn = document.createElement('button');
+            btn.innerText = 'Unequip';
+            btn.onclick = () => fetch('https://gear_system/unequip', {method:'POST', body: JSON.stringify({slot: slot})});
+            el.appendChild(btn);
+        }
+        slotDiv.appendChild(el);
+    }
+}

--- a/gear_system/html/style.css
+++ b/gear_system/html/style.css
@@ -1,0 +1,14 @@
+body {
+    background-color: rgba(0,0,0,0.5);
+    color: #fff;
+    font-family: Arial, sans-serif;
+}
+#gearContainer {
+    display: none;
+    margin: auto;
+    padding: 20px;
+    background: #222;
+}
+.slot {
+    margin-bottom: 5px;
+}

--- a/gear_system/server.lua
+++ b/gear_system/server.lua
@@ -1,0 +1,180 @@
+local Gear = {}
+
+-- utility to compile modify functions
+local function compileFunc(str)
+    local fn = load(str)
+    if type(fn) == 'function' then
+        return fn
+    end
+    return function(base, bonus) return base end
+end
+
+-- prepare modify functions
+for stat, data in pairs(Config.Stats) do
+    data._modify = compileFunc(data.modifyFunction)
+end
+
+local function getEmptyGear()
+    local t = {}
+    for slot, _ in pairs(Config.GearSlots) do
+        t[slot] = nil
+    end
+    return t
+end
+
+local function getPlayerGear(src)
+    if not Gear[src] then
+        Gear[src] = getEmptyGear()
+    end
+    return Gear[src]
+end
+
+local function getIdentifier(src)
+    return GetPlayerIdentifier(src, 0)
+end
+
+local function loadPlayerGear(src)
+    local id = getIdentifier(src)
+    if not id then return end
+    local data = GetResourceKvpString('gear:' .. id)
+    if data then
+        Gear[src] = json.decode(data)
+    else
+        Gear[src] = getEmptyGear()
+    end
+end
+
+local function savePlayerGear(src)
+    local id = getIdentifier(src)
+    if not id then return end
+    SetResourceKvp('gear:' .. id, json.encode(Gear[src] or getEmptyGear()))
+end
+
+local function calculateStats(src)
+    local playerGear = getPlayerGear(src)
+    local stats = {}
+    for name, def in pairs(Config.Stats) do
+        stats[name] = def.default
+    end
+
+    for slot, item in pairs(playerGear) do
+        if item and item.stats then
+            local rarity = Config.Rarities[item.rarity] or {multiplier = 1.0}
+            for stat, value in pairs(item.stats) do
+                if stats[stat] then
+                    stats[stat] = stats[stat] + (value * rarity.multiplier)
+                end
+            end
+        end
+    end
+
+    return stats
+end
+
+local function applyStats(src)
+    local stats = calculateStats(src)
+    TriggerClientEvent('gear_system:client:applyStats', src, stats)
+end
+
+-- exported
+function getPlayerStats(src)
+    return calculateStats(src)
+end
+
+exports('getPlayerStats', getPlayerStats)
+
+-- durability handling
+local function decayDurability(src, slot, amount)
+    if not Config.Durability.enabled then return end
+    local gear = getPlayerGear(src)[slot]
+    if not gear then return end
+    gear.durability = gear.durability - amount
+    if gear.durability <= 0 then
+        gear.durability = 0
+        if Config.Durability.breakRemovesStats then
+            getPlayerGear(src)[slot] = nil
+        end
+    end
+end
+
+-- equipping gear
+RegisterNetEvent('gear_system:server:equip', function(itemName, metadata)
+    local src = source
+    local itemDef = Config.Equipment[itemName]
+    if not itemDef then return end
+    local slot = itemDef.slot
+    local gearSlot = Config.GearSlots[slot]
+    if not gearSlot then return end
+
+    -- remove from inventory and update metadata via qb-inventory
+    if exports['qb-inventory'] then
+        exports['qb-inventory']:RemoveItem(src, itemName, 1)
+    end
+
+    local playerGear = getPlayerGear(src)
+    -- if slot occupied return old item to inventory
+    if playerGear[slot] then
+        local old = playerGear[slot]
+        if exports['qb-inventory'] then
+            exports['qb-inventory']:AddItem(src, old.name, 1, nil, old)
+        end
+    end
+
+    local gearData = {
+        name = itemName,
+        rarity = itemDef.rarity,
+        durability = itemDef.durability,
+        stats = itemDef.stats,
+        slot = slot,
+        type = itemDef.type
+    }
+    playerGear[slot] = gearData
+    savePlayerGear(src)
+    applyStats(src)
+end)
+
+-- event for qb-inventory to trigger on item use
+RegisterNetEvent('gear_system:server:useItem', function(itemName, metadata)
+    TriggerEvent('gear_system:server:equip', itemName, metadata)
+end)
+
+RegisterNetEvent('gear_system:server:unequip', function(slot)
+    local src = source
+    local playerGear = getPlayerGear(src)
+    local gear = playerGear[slot]
+    if not gear then return end
+    playerGear[slot] = nil
+    if exports['qb-inventory'] then
+        exports['qb-inventory']:AddItem(src, gear.name, 1, nil, gear)
+    end
+    savePlayerGear(src)
+    applyStats(src)
+end)
+
+-- stat effect implementations
+AddEventHandler('playerDropped', function(reason)
+    savePlayerGear(source)
+    Gear[source] = nil
+end)
+
+AddEventHandler('playerJoining', function()
+    loadPlayerGear(source)
+    -- apply stats after short delay to ensure player entity exists
+    SetTimeout(1000, function()
+        applyStats(source)
+    end)
+end)
+
+RegisterNetEvent('gear_system:server:requestGear', function()
+    TriggerClientEvent('gear_system:client:setGear', source, getPlayerGear(source))
+end)
+
+-- command to print stats
+RegisterCommand('gearstats', function(src)
+    local stats = calculateStats(src)
+    print('Gear stats for', src, json.encode(stats))
+end)
+
+RegisterCommand('equipment', function(src)
+    TriggerClientEvent('gear_system:client:open', src)
+end)


### PR DESCRIPTION
## Summary
- fix server-side stat handling and move effects to client
- add persistence of gear items and load/apply on join
- send gear to client on request and implement qb-inventory `useItem` event
- hide equipment menu until opened by command

## Testing
- `luac -p gear_system/server.lua` *(fails: command not found)*
- `luac -p gear_system/client.lua` *(fails: command not found)*